### PR TITLE
Add Figma embed page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gover Lite</title>
+    <style>
+        /* Basic reset */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f5f5f5;
+            color: #333;
+            line-height: 1.6;
+        }
+        header {
+            background-color: #004b8d;
+            color: #fff;
+            padding: 20px;
+            text-align: center;
+        }
+        main {
+            max-width: 800px;
+            margin: 40px auto;
+            padding: 0 20px;
+        }
+        iframe {
+            width: 100%;
+            height: 450px;
+            border: 1px solid rgba(0, 0, 0, 0.1);
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Gover Lite</h1>
+    </header>
+    <main>
+        <p>Visual do Figma incorporado:</p>
+        <iframe
+            src="https://embed.figma.com/design/7DAV63VD176qkHzOFEJfiO/Gover-Lite?node-id=0-1&embed-host=share"
+            allowfullscreen>
+        </iframe>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a basic `index.html` that embeds the provided Figma design

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842f07c69f083288359fd3777712d63